### PR TITLE
Add configurable API endpoint and dynamic model loading

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,8 @@
 {
   "translate-all.settings.apiKey.name": "OpenAI API Key",
   "translate-all.settings.apiKey.hint": "Your secret API key to access ChatGPT.",
+  "translate-all.settings.apiEndpoint.name": "API Endpoint",
+  "translate-all.settings.apiEndpoint.hint": "The endpoint to use for the API. Change this if you are using a proxy or a different compatible API.",
   "translate-all.settings.language.name": "Language",
   "translate-all.settings.language.hint": "The language to translate descriptions into.",
   "translate-all.settings.game.system.name": "Select Game System",

--- a/src/handlers/settings-handler.ts
+++ b/src/handlers/settings-handler.ts
@@ -1,3 +1,4 @@
+import { Translator } from "../translator";
 import { KeyFor, SupportedModels, SupportedSystems, TranslateAllNamespace } from "../types";
 
 export class TranslateAllSettingHandler {
@@ -24,6 +25,14 @@ export class TranslateAllSettingHandler {
       default: "",
       masked: true,
     },
+    apiEndpoint: {
+      name: "translate-all.settings.apiEndpoint.name",
+      hint: "translate-all.settings.apiEndpoint.hint",
+      scope: "world",
+      config: true,
+      type: String,
+      default: "https://api.openai.com/v1",
+    },
     targetLanguage: {
       name: "translate-all.settings.language.name",
       hint: "translate-all.settings.language.hint",
@@ -39,25 +48,17 @@ export class TranslateAllSettingHandler {
       scope: "world",
       config: true,
       type: String,
-      default: "gpt-4o-mini", // Default to gpt-4o-mini
-      choices: {
-        [SupportedModels.GPT_4O_MINI]: "GPT-4o Mini",
-        [SupportedModels.GPT_4_1]: "GPT-4.1",
-        [SupportedModels.GPT_4_1_MINI]: "GPT-4.1 Mini",
-        [SupportedModels.GPT_4_1_NANO]: "GPT-4.1 Nano",
-        [SupportedModels.GPT_4_TURBO]: "GPT-4 Turbo",
-        [SupportedModels.GPT_3_5_TURBO]: "GPT-3.5 Turbo",
-      },
+      default: "gpt-4o-mini",
     },
   };
 
   constructor() {}
 
-  init(): void {
-    this._registerSettings();
+  async init(): Promise<void> {
+    await this._registerSettings();
   }
 
-  private _registerSettings(): void {
+  private async _registerSettings(): Promise<void> {
     this._register(
       "translate-all" as TranslateAllNamespace,
       "targetSystem" as KeyFor<TranslateAllNamespace>,
@@ -70,9 +71,18 @@ export class TranslateAllSettingHandler {
     );
     this._register(
       "translate-all" as TranslateAllNamespace,
+      "apiEndpoint" as KeyFor<TranslateAllNamespace>,
+      this.settings.apiEndpoint,
+    );
+    this._register(
+      "translate-all" as TranslateAllNamespace,
       "targetLanguage" as KeyFor<TranslateAllNamespace>,
       this.settings.targetLanguage,
     );
+    const models = await Translator.getModels();
+    if (models) {
+      this.settings.targetModel.choices = models;
+    }
     this._register(
       "translate-all" as TranslateAllNamespace,
       "targetModel" as KeyFor<TranslateAllNamespace>,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,13 @@ import { HTMLHandler } from "handlers/html-handler";
 import { TranslateAllSettingHandler } from "handlers/settings-handler";
 import { SupportedEntries, SupportedSystems } from "types";
 
-Hooks.once("init", () => {
+Hooks.once("init", async () => {
   if (!game.settings) {
     ui?.notifications?.error(`Game settings are not available. This module requires Foundry VTT version 10 or later.`);
     return;
   }
   const settingHandler = new TranslateAllSettingHandler();
-  settingHandler.init();
+  await settingHandler.init();
 });
 
 Hooks.on("renderJournalPageSheet", async (app: JournalPageSheet, html: JQuery<HTMLElement>) => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -14,16 +14,50 @@ export class Translator {
     return prompt;
   }
 
+  static async getModels(): Promise<Record<string, string> | undefined> {
+    let response;
+    const apiKey = TranslateAllSettingHandler.getSetting("translate-all", "apiKey");
+    const apiEndpoint = TranslateAllSettingHandler.getSetting("translate-all", "apiEndpoint");
+
+    try {
+      response = await fetch(`${apiEndpoint}/models`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+    } catch (error) {
+      ui?.notifications?.error(`ChatGPT API call failed. ${error}`);
+    }
+
+    if (!response?.ok) {
+      ui?.notifications?.error("ChatGPT API call failed.");
+      return undefined;
+    }
+
+    const data = await response.json();
+    const models = data.data.reduce(
+      (acc: Record<string, string>, model: { id: string }) => {
+        acc[model.id] = model.id;
+        return acc;
+      },
+      {},
+    );
+    return models;
+  }
+
   static async translateWithChatGPT(description: string): Promise<string | undefined> {
     let response;
     const apiKey = TranslateAllSettingHandler.getSetting("translate-all", "apiKey");
+    const apiEndpoint = TranslateAllSettingHandler.getSetting("translate-all", "apiEndpoint");
     const system = TranslateAllSettingHandler.getSetting("translate-all", "targetSystem") as SupportedSystems;
     const language = TranslateAllSettingHandler.getSetting("translate-all", "targetLanguage") as SupportedLanguages;
     const model = TranslateAllSettingHandler.getSetting("translate-all", "targetModel");
     const prompt = Translator.generatePrompt(system, language, description);
 
     try {
-      response = await fetch("https://api.openai.com/v1/chat/completions", {
+      response = await fetch(`${apiEndpoint}/chat/completions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface TranslateConfigSettingConfig {
   'translate-all.targetSystem': string;
   'translate-all.targetLanguage': string;
   'translate-all.targetModel': string;
+  'translate-all.apiEndpoint': string;
 }
 
 export type TranslateAllNamespace = typeof MODULE_NAME | ClientSettings.Namespace;


### PR DESCRIPTION
Introduces an 'API Endpoint' setting to allow users to specify a custom API URL, supporting proxies or alternative endpoints. The available model choices are now dynamically loaded from the API, improving flexibility and compatibility with different OpenAI-compatible services.

![Image](https://github.com/user-attachments/assets/b29451ea-dfdd-43ea-8f85-e9eb72097416)

![Image](https://github.com/user-attachments/assets/c2417877-0af1-4c67-b832-d98208044499)

Has passed a simple test.

https://github.com/AlessandroSantarini/translate-all/issues/4